### PR TITLE
Null is inserted instead of StringBuilder object when StringBuilder.insert() is executed.

### DIFF
--- a/src/conversion/FileProcessor.ts
+++ b/src/conversion/FileProcessor.ts
@@ -45,6 +45,7 @@ import { IClassResolver, IConverterConfiguration } from "./JavaToTypeScript";
 import { EnumSymbol, JavaInterfaceSymbol } from "../parsing/JavaParseTreeWalker";
 import { PackageSourceManager } from "../PackageSourceManager";
 import { EnhancedTypeKind, ISymbolInfo } from "./types";
+import {validateHeaderName} from "http";
 
 enum ModifierType {
     None,
@@ -267,8 +268,13 @@ export class FileProcessor {
                 this.processCompilationUnit(builder, this.source.targetFile, libPath, this.source.parseTree);
 
                 try {
+                    let converted = builder.toString();
+                    this.configuration.targetReplace?.forEach((to: string, pattern: RegExp) => {
+                        converted = converted.replace(pattern, to)
+                    });
+
                     fs.mkdirSync(path.dirname(this.source.targetFile), { recursive: true });
-                    fs.writeFileSync(this.source.targetFile, builder.toString());
+                    fs.writeFileSync(this.source.targetFile, converted);
                     console.log(" done");
                 } catch (e) {
                     console.log("failed");

--- a/src/lib/java/lang/StringBuilder.ts
+++ b/src/lib/java/lang/StringBuilder.ts
@@ -603,7 +603,7 @@ export class StringBuilder implements java.lang.CharSequence, java.lang.Appendab
 
             if (position < this.currentLength) {
                 // Copy the rest from the original data.
-                newData.set(this.data.subarray(position, this.currentLength), position);
+                newData.set(this.data.subarray(position, this.currentLength), additionalSize);
             }
 
             this.data = newData;

--- a/src/test/lang/StringBuilder.spec.ts
+++ b/src/test/lang/StringBuilder.spec.ts
@@ -5,10 +5,26 @@
  * See LICENSE-MIT.txt file for more info.
  */
 
+import { java } from "../../lib/java/java";
+
 export { };
 
 describe("Tests", () => {
-    it("Base", () => {
-        //
+    it("Prepend raw string", () => {
+        const builder = new java.lang.StringBuilder();
+        builder.append('abc');
+        builder.insert(0, 'def');
+        expect(builder.toString()).toBe('defabc');
+    });
+
+    it("Prepend StringBuilder", () => {
+        const builder = new java.lang.StringBuilder();
+        builder.append('abc');
+
+        const prepend = new java.lang.StringBuilder();
+        prepend.append( 'def');
+
+        builder.insert(0, prepend);
+        expect(builder.toString()).toBe('defabc');
     });
 });


### PR DESCRIPTION
Hello, @mike-lischke 

Thanks for developing this.
While using it, I found that a few bytes of null characters were added. In the current code, the `Prepend StringBuilder` test case will fail and this problem will be reproduced.
So I modified the code, please check it.