### PR TITLE
fix: Fixed bug causing IndexOutOfBoundsException when deleting last character from StringBuilder

### DIFF
--- a/src/lib/java/lang/StringBuilder.ts
+++ b/src/lib/java/lang/StringBuilder.ts
@@ -207,7 +207,7 @@ export class StringBuilder extends JavaObject implements java.lang.CharSequence,
             throw new java.lang.IndexOutOfBoundsException();
         }
 
-        if (end < 0 || end >= this.currentLength) {
+        if (end < 0 || end > this.currentLength) {
             throw new java.lang.IndexOutOfBoundsException();
         }
 

--- a/src/test/lib/java/lang/StringBuilder.spec.ts
+++ b/src/test/lib/java/lang/StringBuilder.spec.ts
@@ -7,8 +7,6 @@
 
 import { java } from "../../../../lib/java/java";
 
-export { };
-
 describe("Tests", () => {
     it("Construction", () => {
         expect(new java.lang.StringBuilder().length() === 0);
@@ -94,5 +92,30 @@ describe("Tests", () => {
         b.insert(b.length(), i);   // JavaObject
 
         expect(`${b.toString()}`).toBe("String Builder-1String Builder-2123\n3true-4Another string-5-456");
+    });
+
+    it("Delete content", () => {
+        const b0 = new java.lang.StringBuilder("1234");
+        b0.deleteCharAt(0);
+        expect(`${b0.toString()}`).toBe("234");
+
+        const b1 = new java.lang.StringBuilder("1234");
+        b1.deleteCharAt(1);
+        expect(`${b1.toString()}`).toBe("134");
+
+        const b2 = new java.lang.StringBuilder("1234");
+        b2.deleteCharAt(2);
+        expect(`${b2.toString()}`).toBe("124");
+
+        const b3 = new java.lang.StringBuilder("1234");
+        b3.deleteCharAt(3);
+        expect(`${b3.toString()}`).toBe("123");
+
+        try {
+            const b4 = new java.lang.StringBuilder("1234");
+            b4.deleteCharAt(4);
+        } catch (e) {
+            expect(e).toBeInstanceOf(java.lang.IndexOutOfBoundsException);
+        }
     });
 });


### PR DESCRIPTION
Hello, @mike-lischke 

IndexOutOfBoundsException thrown when deleting last character from StringBuilder.
I met this issue in https://github.com/mike-lischke/java2typescript/blob/3b3b1c153971a6b47dec312708ce3d0729f2e59e/src/conversion/FileProcessor.ts#L2216

Please review and merge if appropriate.
Thank you.

```
const b3 = new java.lang.StringBuilder("1234");
b3.deleteCharAt(3); // <- throws IndexOutOfBoundsException error
```